### PR TITLE
fix: use "browser" resolution in build

### DIFF
--- a/rollup/rollup.config.js
+++ b/rollup/rollup.config.js
@@ -227,6 +227,7 @@ export default {
     // resolve bare module imports
     resolve({
       preferBuiltins: false,
+      browser: true,
     }),
 
     // monkey patch some modules


### PR DESCRIPTION
fixes #4

Ensure that the browser targeted build uses the `browser` resolution method to ensure that node packages aren't required to deliver functionality.

Thanks @benjamind for pointing me in the right direction!

I ran `build` locally and manually copied the output into my project to test and this update worked as expected. Not sure what other testing processes are available for this project.